### PR TITLE
Update webhook to accept JSON body

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ renovation.  The request is forwarded to OpenAI's API using the
    python app.py
    ```
 
-4. Configure your Typebot flow to send a `POST` request with a file field
-   named `file` and a text field named `prompt` to the `/typebot-webhook`
-   endpoint.
+4. Configure your Typebot flow to send a `POST` request to the
+   `/typebot-webhook` endpoint. You can either send multipart form-data with
+   a file field named `file` and a text field named `prompt`, or send a JSON
+   body with keys `file` (containing an image URL) and `prompt`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.1.0
 openai==1.61.1
 python-dotenv==1.0.1
 gunicorn==21.2.0
+requests==2.31.0


### PR DESCRIPTION
## Summary
- extend `/typebot-webhook` endpoint to support JSON body containing `file` and `prompt`
- fetch image when JSON payload is used
- document JSON option in README
- add `requests` as dependency

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6846c3aff3f8833182fa0b7971673e5d