### PR TITLE
Handle image download timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,7 @@ renovation.  The request is forwarded to OpenAI's API using the
 4. Configure your Typebot flow to send a `POST` request to the
    `/typebot-webhook` endpoint. You can either send multipart form-data with
    a file field named `file` and a text field named `prompt`, or send a JSON
-   body with keys `file` (containing an image URL) and `prompt`.
+    body with keys `file` (containing an image URL) and `prompt`. When using
+    the JSON approach the server downloads the image with a 10‑second
+    timeout. If the download does not finish in time, the API responds with a
+    `504` error.

--- a/app.py
+++ b/app.py
@@ -27,11 +27,13 @@ def typebot_webhook():
         if not prompt or not image_url:
             return jsonify({'error': 'missing prompt or file'}), 400
 
-        # Fetch the image from the provided URL
+        # Fetch the image from the provided URL with a timeout
         try:
-            resp = requests.get(image_url)
+            resp = requests.get(image_url, timeout=10)
             resp.raise_for_status()
             img_bytes = resp.content
+        except requests.exceptions.Timeout:
+            return jsonify({'error': 'image download timed out'}), 504
         except Exception as exc:
             return jsonify({'error': f'failed to fetch image: {exc}'}), 400
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,17 @@
+import os
+from unittest.mock import patch
+import requests
+
+# Ensure OpenAI key is set so app can import
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from app import app
+
+
+def test_image_download_timeout():
+    client = app.test_client()
+    with patch('requests.get', side_effect=requests.exceptions.Timeout):
+        resp = client.post('/typebot-webhook', json={'file': 'http://example.com/img.jpg', 'prompt': 'design'})
+    assert resp.status_code == 504
+    assert resp.is_json
+    assert resp.get_json() == {'error': 'image download timed out'}


### PR DESCRIPTION
## Summary
- handle request timeout for image downloads
- note timeout error in README
- test JSON image download timeout

## Testing
- `pytest -q tests/test_app.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68499f393f2c833189da29ca5bbe3afb