### PR TITLE
Handle long running OpenAI edits asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ renovation.  The request is forwarded to OpenAI's API using the
     the JSON approach the server downloads the image with a 10‑second
     timeout. If the download does not finish in time, the API responds with a
     `504` error.
+
+   The OpenAI call runs in the background. The webhook immediately returns a
+   `task_id`:
+
+   ```json
+   {"task_id": "<uuid>"}
+   ```
+
+   Poll `GET /task/<task_id>` to retrieve the result. While processing, the
+   endpoint returns a `202` status with `{"status": "pending"}`. When done it
+   responds with the generated `image_url`.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -15,3 +15,27 @@ def test_image_download_timeout():
     assert resp.status_code == 504
     assert resp.is_json
     assert resp.get_json() == {'error': 'image download timed out'}
+
+
+def test_task_is_created():
+    client = app.test_client()
+
+    class DummyThread:
+        def __init__(self, target, daemon=None):
+            self.target = target
+        def start(self):
+            self.target()
+
+    with patch('requests.get') as mock_get, \
+         patch('app.threading.Thread', DummyThread), \
+         patch.object(app.client.images, 'edit') as mock_edit:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = b'data'
+        mock_edit.return_value.data = [type('obj', (object,), {'url': 'http://fake'})]
+        resp = client.post('/typebot-webhook', json={'file': 'http://x/img.jpg', 'prompt': 'design'})
+    assert resp.status_code == 202
+    data = resp.get_json()
+    assert 'task_id' in data
+    task = app.tasks[data['task_id']]
+    assert task['status'] == 'done'
+    assert task['result']['image_url'] == 'http://fake'


### PR DESCRIPTION
## Summary
- handle OpenAI image editing in a background thread
- expose `/task/<task_id>` endpoint to poll for the result
- document the asynchronous flow in README
- test creation of task ids

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6849aa543f5883318797ee4d6ecd6d65